### PR TITLE
Suggestions

### DIFF
--- a/02-text-processing/README.md
+++ b/02-text-processing/README.md
@@ -62,6 +62,7 @@ Searching:
 * `/` lets you search for a string. It searches forward from the current position in the file. e.g. `/hello<enter>`
 * `?` searches backwards from the current position in the file. e.g. `?hello<enter>`
 * `n` jumps to the next match
+* `Shift-n` jumps to the previous match
 
 To exit the program, press `q`.
 

--- a/02-text-processing/README.md
+++ b/02-text-processing/README.md
@@ -68,10 +68,6 @@ To exit the program, press `q`.
 
 Exercise: Run `less README.md` and familiarise yourself with the keys for navigation and searching. Try searching for "hello".
 
-### more
-
-Don't use `more`. It's an older, worse version of `less`.
-
 ### head and tail
 
 You can look at the first few or last few lines of a file using `head` or `tail`.


### PR DESCRIPTION
Previous search in less is pretty much essential when skimming through matches in large log files (I always overshoot). Also removes `more`. As I say [in that commit](https://github.com/cb372/cli-tools-skills-amnesty/commit/3c0de5041df2b912e2427d62a710e33de6a4cec9), no need to mention things the pupil _shouldn't_ use.
